### PR TITLE
Fix typo in ec2.CreateVolume

### DIFF
--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -1607,7 +1607,7 @@ func (ec2 *EC2) CreateVolume(options CreateVolumeOptions) (resp *CreateVolumeRes
 	if options.SnapshotId != "" {
 		params["SnapshotId"] = options.SnapshotId
 	}
-	if options.SnapshotId != "" {
+	if options.VolumeType != "" {
 		params["VolumeType"] = options.VolumeType
 	}
 	if options.IOPS > 0 {


### PR DESCRIPTION
Hello,

When I made #278, I made a typo in ec2.go. It checks the wrong field in options to set `VolumeType`. I finally got around to implement a feature that uses that call.

Cheers