### PR TITLE
Fix the typo in ec2.DescribeVolumes

### DIFF
--- a/ec2/ec2.go
+++ b/ec2/ec2.go
@@ -1537,7 +1537,7 @@ type DescribeVolumesResp struct {
 
 func (ec2 *EC2) DescribeVolumes(volIds []string, filter *Filter) (resp *DescribeVolumesResp, err error) {
 	params := makeParams("DescribeVolumes")
-	addParamsList(params, "VolumeIds", volIds)
+	addParamsList(params, "VolumeId", volIds)
 	filter.addParams(params)
 	resp = &DescribeVolumesResp{}
 	err = ec2.query(params, resp)


### PR DESCRIPTION
Hello,

I was implementing a feature that uses `CreateVolume`, and found that `DescribeVolumes` doesn't work, because the parameter is misspelled (has an extra s at the end). See http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeVolumes.html for the reference.

Cheers