### PR TITLE
Return DynamoDB GetItem error instead of JSON parse error

### DIFF
--- a/dynamodb/item.go
+++ b/dynamodb/item.go
@@ -139,6 +139,9 @@ func (t *Table) getItem(key *Key, consistentRead bool) (map[string]*Attribute, e
 	}
 
 	jsonResponse, err := t.Server.queryServer(target("GetItem"), q)
+	if err != nil {
+		return nil, err
+	}
 
 	json, err := simplejson.NewJson(jsonResponse)
 	if err != nil {


### PR DESCRIPTION
If an error occurs during GetItem, that error should be returned to the client. In the case where the response was empty, EOF is being returned from the failing JSON parse.