### PR TITLE
add sns notification request object

### DIFF
--- a/sns/http_notification_test.go
+++ b/sns/http_notification_test.go
@@ -1,0 +1,16 @@
+package sns_test
+
+var HttpNotificationRequest = `
+{
+  "Type" : "Notification",
+  "MessageId" : "22b80b92-fdea-4c2c-8f9d-bdfb0c7bf324",
+  "TopicArn" : "arn:aws:sns:us-east-1:123456789012:MyTopic",
+  "Subject" : "My First Message",
+  "Message" : "Hello world!",
+  "Timestamp" : "2012-05-02T00:54:06.655Z",
+  "SignatureVersion" : "1",
+  "Signature" : "EXAMPLEw6JRNwm1LFQL4ICB0bnXrdB8ClRMTQFGBqwLpGbM78tJ4etTwC5zU7O3tS6tGpey3ejedNdOJ+1fkIp9F2/LmNVKb5aFlYq+9rk9ZiPph5YlLmWsDcyC5T+Sy9/umic5S0UQc2PEtgdpVBahwNOdMW4JPwk0kAJJztnc=",
+  "SigningCertURL" : "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-f3ecfb7224c7233fe7bb5f59f96de52f.pem",
+  "UnsubscribeURL" : "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:123456789012:MyTopic:c9135db0-26c4-47ec-8998-413945fb5a96"
+}
+`

--- a/sns/responses_test.go
+++ b/sns/responses_test.go
@@ -323,7 +323,6 @@ var TestListPlatformApplicationsXmlOK = `
   </ResponseMetadata>
 </ListPlatformApplicationsResponse>
 `
-
 var TestSetEndpointAttributesXmlOK = `
 <SetEndpointAttributesResponse xmlns="http://sns.amazonaws.com/doc/2010-03-31/">
   <ResponseMetadata>

--- a/sns/sns_test.go
+++ b/sns/sns_test.go
@@ -1,6 +1,7 @@
 package sns_test
 
 import (
+	"encoding/json"
 	"github.com/crowdmob/goamz/aws"
 	"github.com/crowdmob/goamz/sns"
 	"github.com/crowdmob/goamz/testutil"
@@ -469,5 +470,11 @@ func (s *S) TestSetPlatformApplicationAttributes(c *check.C) {
 
 	c.Assert(resp.ResponseMetadata.RequestId, check.Equals, "cf577bcc-b3dc-5463-88f1-3180b9412395")
 
+	c.Assert(err, check.IsNil)
+}
+
+func (s *S) TestHttpNotificationUnmarshalling(c *check.C) {
+	notification := sns.HttpNotification{}
+	err := json.Unmarshal([]byte(HttpNotificationRequest), &notification)
 	c.Assert(err, check.IsNil)
 }

--- a/sns/structs.go
+++ b/sns/structs.go
@@ -175,3 +175,18 @@ type SetEndpointAttributesResponse struct {
 type SetPlatformApplicationAttributesResponse struct {
 	ResponseMetadata aws.ResponseMetadata
 }
+
+//===== Notification ======
+// http://docs.aws.amazon.com/sns/latest/dg/json-formats.html#http-notification-json
+type HttpNotification struct {
+	Type             string `json:"Type"`
+	MessageId        string `json:"MessageId"`
+	TopicArn         string `json:"TopicArn"`
+	Subject          string `json:"Subject"`
+	Message          string `json:"Message"`
+	Timestamp        string `json:"Rimestamp"`
+	SignatureVersion string `json:"SignatureVersion"`
+	Signature        string `json:"Signature"`
+	SigningCertURL   string `json:"SigningCertURL"`
+	UnsubscribeURL   string `json:"UnsubscribeURL"`
+}


### PR DESCRIPTION
This is my attempt to implement http://docs.aws.amazon.com/sns/latest/dg/json-formats.html#http-notification-json

How did you guys use the sns library without that? Or did I miss something?