### PR TITLE
Additional tests and Subscribe/Unsubscribe support for SNS json notifications

### DIFF
--- a/sns/http_notification_test.go
+++ b/sns/http_notification_test.go
@@ -1,5 +1,20 @@
 package sns_test
 
+var HttpSubscriptionConfirmationRequest = `
+{
+  "Type" : "SubscriptionConfirmation",
+  "MessageId" : "165545c9-2a5c-472c-8df2-7ff2be2b3b1b",
+  "Token" : "2336412f37fb687f5d51e6e241d09c805a5a57b30d712f794cc5f6a988666d92768dd60a747ba6f3beb71854e285d6ad02428b09ceece29417f1f02d609c582afbacc99c583a916b9981dd2728f4ae6fdb82efd087cc3b7849e05798d2d2785c03b0879594eeac82c01f235d0e717736",
+  "TopicArn" : "arn:aws:sns:us-east-1:123456789012:MyTopic",
+  "Message" : "You have chosen to subscribe to the topic arn:aws:sns:us-east-1:123456789012:MyTopic.\nTo confirm the subscription, visit the SubscribeURL included in this message.",
+  "SubscribeURL" : "https://sns.us-east-1.amazonaws.com/?Action=ConfirmSubscription&TopicArn=arn:aws:sns:us-east-1:123456789012:MyTopic&Token=2336412f37fb687f5d51e6e241d09c805a5a57b30d712f794cc5f6a988666d92768dd60a747ba6f3beb71854e285d6ad02428b09ceece29417f1f02d609c582afbacc99c583a916b9981dd2728f4ae6fdb82efd087cc3b7849e05798d2d2785c03b0879594eeac82c01f235d0e717736",
+  "Timestamp" : "2012-04-26T20:45:04.751Z",
+  "SignatureVersion" : "1",
+  "Signature" : "EXAMPLEpH+DcEwjAPg8O9mY8dReBSwksfg2S7WKQcikcNKWLQjwu6A4VbeS0QHVCkhRS7fUQvi2egU3N858fiTDN6bkkOxYDVrY0Ad8L10Hs3zH81mtnPk5uvvolIC1CXGu43obcgFxeL3khZl8IKvO61GWB6jI9b5+gLPoBc1Q=",
+  "SigningCertURL" : "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-f3ecfb7224c7233fe7bb5f59f96de52f.pem"
+}
+`
+
 var HttpNotificationRequest = `
 {
   "Type" : "Notification",
@@ -12,5 +27,20 @@ var HttpNotificationRequest = `
   "Signature" : "EXAMPLEw6JRNwm1LFQL4ICB0bnXrdB8ClRMTQFGBqwLpGbM78tJ4etTwC5zU7O3tS6tGpey3ejedNdOJ+1fkIp9F2/LmNVKb5aFlYq+9rk9ZiPph5YlLmWsDcyC5T+Sy9/umic5S0UQc2PEtgdpVBahwNOdMW4JPwk0kAJJztnc=",
   "SigningCertURL" : "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-f3ecfb7224c7233fe7bb5f59f96de52f.pem",
   "UnsubscribeURL" : "https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:123456789012:MyTopic:c9135db0-26c4-47ec-8998-413945fb5a96"
+}
+`
+
+var HttpUnsubscribeConfirmationRequest = `
+{
+  "Type" : "UnsubscribeConfirmation",
+  "MessageId" : "47138184-6831-46b8-8f7c-afc488602d7d",
+  "Token" : "2336412f37fb687f5d51e6e241d09c805a5a57b30d712f7948a98bac386edfe3e10314e873973b3e0a3c09119b722dedf2b5e31c59b13edbb26417c19f109351e6f2169efa9085ffe97e10535f4179ac1a03590b0f541f209c190f9ae23219ed6c470453e06c19b5ba9fcbb27daeb7c7",
+  "TopicArn" : "arn:aws:sns:us-east-1:123456789012:MyTopic",
+  "Message" : "You have chosen to deactivate subscription arn:aws:sns:us-east-1:123456789012:MyTopic:2bcfbf39-05c3-41de-beaa-fcfcc21c8f55.\nTo cancel this operation and restore the subscription, visit the SubscribeURL included in this message.",
+  "SubscribeURL" : "https://sns.us-east-1.amazonaws.com/?Action=ConfirmSubscription&TopicArn=arn:aws:sns:us-east-1:123456789012:MyTopic&Token=2336412f37fb687f5d51e6e241d09c805a5a57b30d712f7948a98bac386edfe3e10314e873973b3e0a3c09119b722dedf2b5e31c59b13edbb26417c19f109351e6f2169efa9085ffe97e10535f4179ac1a03590b0f541f209c190f9ae23219ed6c470453e06c19b5ba9fcbb27daeb7c7",
+  "Timestamp" : "2012-04-26T20:06:41.581Z",
+  "SignatureVersion" : "1",
+  "Signature" : "EXAMPLEHXgJmXqnqsHTlqOCk7TIZsnk8zpJJoQbr8leD+8kAHcke3ClC4VPOvdpZo9s/vR9GOznKab6sjGxE8uwqDI9HwpDm8lGxSlFGuwCruWeecnt7MdJCNh0XK4XQCbtGoXB762ePJfaSWi9tYwzW65zAFU04WkNBkNsIf60=",
+  "SigningCertURL" : "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-f3ecfb7224c7233fe7bb5f59f96de52f.pem"
 }
 `

--- a/sns/sns_test.go
+++ b/sns/sns_test.go
@@ -473,8 +473,35 @@ func (s *S) TestSetPlatformApplicationAttributes(c *check.C) {
 	c.Assert(err, check.IsNil)
 }
 
-func (s *S) TestHttpNotificationUnmarshalling(c *check.C) {
+func (s *S) TestHttpSubscriptionConfirmationRequestUnmarshalling(c *check.C) {
+	notification := sns.HttpNotification{}
+	err := json.Unmarshal([]byte(HttpSubscriptionConfirmationRequest), &notification)
+	c.Assert(err, check.IsNil)
+	c.Assert(notification.Token, check.NotNil)
+	c.Assert(notification.Subject, check.Equals, "")
+	c.Assert(notification.SubscribeURL, check.NotNil)
+	c.Assert(notification.UnsubscribeURL, check.Equals, "")
+	c.Assert(notification.Type, check.Equals, sns.MESSAGE_TYPE_SUBSCRIPTION_CONFIRMATION)
+}
+
+func (s *S) TestHttpNotificationRequestUnmarshalling(c *check.C) {
 	notification := sns.HttpNotification{}
 	err := json.Unmarshal([]byte(HttpNotificationRequest), &notification)
 	c.Assert(err, check.IsNil)
+	c.Assert(notification.Token, check.Equals, "")
+	c.Assert(notification.Subject, check.NotNil)
+	c.Assert(notification.SubscribeURL, check.Equals, "")
+	c.Assert(notification.UnsubscribeURL, check.NotNil)
+	c.Assert(notification.Type, check.Equals, sns.MESSAGE_TYPE_NOTIFICATION)
+}
+
+func (s *S) TestHttpUnsubscribeConfirmationRequestUnmarshalling(c *check.C) {
+	notification := sns.HttpNotification{}
+	err := json.Unmarshal([]byte(HttpUnsubscribeConfirmationRequest), &notification)
+	c.Assert(err, check.IsNil)
+	c.Assert(notification.Token, check.NotNil)
+	c.Assert(notification.Subject, check.Equals, "")
+	c.Assert(notification.SubscribeURL, check.NotNil)
+	c.Assert(notification.UnsubscribeURL, check.Equals, "")
+	c.Assert(notification.Type, check.Equals, sns.MESSAGE_TYPE_UNSUBSCRIBE_CONFIRMATION)
 }

--- a/sns/structs.go
+++ b/sns/structs.go
@@ -2,6 +2,7 @@ package sns
 
 import (
 	"github.com/crowdmob/goamz/aws"
+	"time"
 )
 
 type Topic struct {
@@ -176,17 +177,29 @@ type SetPlatformApplicationAttributesResponse struct {
 	ResponseMetadata aws.ResponseMetadata
 }
 
-//===== Notification ======
+//===== Http Json messages ======
+
+const (
+	MESSAGE_TYPE_SUBSCRIPTION_CONFIRMATION = "SubscriptionConfirmation"
+	MESSAGE_TYPE_UNSUBSCRIBE_CONFIRMATION  = "UnsubscribeConfirmation"
+	MESSAGE_TYPE_NOTIFICATION              = "Notification"
+)
+
+// Json http notifications
+// http://docs.aws.amazon.com/sns/latest/dg/json-formats.html#http-subscription-confirmation-json
 // http://docs.aws.amazon.com/sns/latest/dg/json-formats.html#http-notification-json
+// http://docs.aws.amazon.com/sns/latest/dg/json-formats.html#http-unsubscribe-confirmation-json
 type HttpNotification struct {
-	Type             string `json:"Type"`
-	MessageId        string `json:"MessageId"`
-	TopicArn         string `json:"TopicArn"`
-	Subject          string `json:"Subject"`
-	Message          string `json:"Message"`
-	Timestamp        string `json:"Rimestamp"`
-	SignatureVersion string `json:"SignatureVersion"`
-	Signature        string `json:"Signature"`
-	SigningCertURL   string `json:"SigningCertURL"`
-	UnsubscribeURL   string `json:"UnsubscribeURL"`
+	Type             string    `json:"Type"`
+	MessageId        string    `json:"MessageId"`
+	Token            string    `json:"Token" optional` // Only for subscribe and unsubscribe
+	TopicArn         string    `json:"TopicArn"`
+	Subject          string    `json:"Subject" optional` // Only for Notification
+	Message          string    `json:"Message"`
+	SubscribeURL     string    `json:"SubscribeURL" optional` // Only for subscribe and unsubscribe
+	Timestamp        time.Time `json:"Timestamp"`
+	SignatureVersion string    `json:"SignatureVersion"`
+	Signature        string    `json:"Signature"`
+	SigningCertURL   string    `json:"SigningCertURL"`
+	UnsubscribeURL   string    `json:"UnsubscribeURL" optional` // Only for notifications
 }


### PR DESCRIPTION
Additional tests and support for Subscribe and Unsubscribe. 

@alimoeeny I was thinking that the `SubscribeURL`, `UnsubscribeURL` fields contain already the callback url to subscribe and unsubscribe. Is it worth adding a method like `func (n* SNSNotification) DoUnsubscribe() error`, or would it be a duplicate of `SNS.Unsubscribe(...)`?

In my code I wrote something like the following which however could be a method of SNSNotification
```
func ConfirmSubscribe(notification SNSNotification, sns SNS) (resp, error) {
     resp, err := sns.ConfirmSubscription(notification.TopicArn, notification.Token, "false")
}
```