### PR TITLE
S3: Fix presigning of URLs

### DIFF
--- a/s3/s3.go
+++ b/s3/s3.go
@@ -823,7 +823,6 @@ func (b *Bucket) UploadSignedURL(path, method, content_type string, expires time
 		method = "PUT"
 	}
 	stringToSign := method + "\n\n" + content_type + "\n" + strconv.FormatInt(expire_date, 10) + "\n/" + b.Name + "/" + path
-	fmt.Println("String to sign:\n", stringToSign)
 	a := b.S3.Auth
 	secretKey := a.SecretKey
 	accessId := a.AccessKey


### PR DESCRIPTION
Signing was broken when pre-signing a URL with credentials using a token (like for example when they come from the instance metadata service on EC2).