### PR TITLE
sns http support - minor refactoring and added helper methods

### DIFF
--- a/sns/http_notifications.go
+++ b/sns/http_notifications.go
@@ -1,0 +1,31 @@
+package sns
+
+import (
+	"time"
+)
+
+const (
+	MESSAGE_TYPE_SUBSCRIPTION_CONFIRMATION = "SubscriptionConfirmation"
+	MESSAGE_TYPE_UNSUBSCRIBE_CONFIRMATION  = "UnsubscribeConfirmation"
+	MESSAGE_TYPE_NOTIFICATION              = "Notification"
+)
+
+// Json http notifications
+// SNS posts those to your http url endpoint if http is selected as delivery method.
+// http://docs.aws.amazon.com/sns/latest/dg/json-formats.html#http-subscription-confirmation-json
+// http://docs.aws.amazon.com/sns/latest/dg/json-formats.html#http-notification-json
+// http://docs.aws.amazon.com/sns/latest/dg/json-formats.html#http-unsubscribe-confirmation-json
+type HttpNotification struct {
+	Type             string    `json:"Type"`
+	MessageId        string    `json:"MessageId"`
+	Token            string    `json:"Token" optional` // Only for subscribe and unsubscribe
+	TopicArn         string    `json:"TopicArn"`
+	Subject          string    `json:"Subject" optional` // Only for Notification
+	Message          string    `json:"Message"`
+	SubscribeURL     string    `json:"SubscribeURL" optional` // Only for subscribe and unsubscribe
+	Timestamp        time.Time `json:"Timestamp"`
+	SignatureVersion string    `json:"SignatureVersion"`
+	Signature        string    `json:"Signature"`
+	SigningCertURL   string    `json:"SigningCertURL"`
+	UnsubscribeURL   string    `json:"UnsubscribeURL" optional` // Only for notifications
+}

--- a/sns/http_notifications_test.go
+++ b/sns/http_notifications_test.go
@@ -1,5 +1,11 @@
 package sns_test
 
+import (
+	"encoding/json"
+	"github.com/crowdmob/goamz/sns"
+	"gopkg.in/check.v1"
+)
+
 var HttpSubscriptionConfirmationRequest = `
 {
   "Type" : "SubscriptionConfirmation",
@@ -44,3 +50,36 @@ var HttpUnsubscribeConfirmationRequest = `
   "SigningCertURL" : "https://sns.us-east-1.amazonaws.com/SimpleNotificationService-f3ecfb7224c7233fe7bb5f59f96de52f.pem"
 }
 `
+
+func (s *S) TestHttpSubscriptionConfirmationRequestUnmarshalling(c *check.C) {
+	notification := sns.HttpNotification{}
+	err := json.Unmarshal([]byte(HttpSubscriptionConfirmationRequest), &notification)
+	c.Assert(err, check.IsNil)
+	c.Assert(notification.Token, check.NotNil)
+	c.Assert(notification.Subject, check.Equals, "")
+	c.Assert(notification.SubscribeURL, check.NotNil)
+	c.Assert(notification.UnsubscribeURL, check.Equals, "")
+	c.Assert(notification.Type, check.Equals, sns.MESSAGE_TYPE_SUBSCRIPTION_CONFIRMATION)
+}
+
+func (s *S) TestHttpNotificationRequestUnmarshalling(c *check.C) {
+	notification := sns.HttpNotification{}
+	err := json.Unmarshal([]byte(HttpNotificationRequest), &notification)
+	c.Assert(err, check.IsNil)
+	c.Assert(notification.Token, check.Equals, "")
+	c.Assert(notification.Subject, check.NotNil)
+	c.Assert(notification.SubscribeURL, check.Equals, "")
+	c.Assert(notification.UnsubscribeURL, check.NotNil)
+	c.Assert(notification.Type, check.Equals, sns.MESSAGE_TYPE_NOTIFICATION)
+}
+
+func (s *S) TestHttpUnsubscribeConfirmationRequestUnmarshalling(c *check.C) {
+	notification := sns.HttpNotification{}
+	err := json.Unmarshal([]byte(HttpUnsubscribeConfirmationRequest), &notification)
+	c.Assert(err, check.IsNil)
+	c.Assert(notification.Token, check.NotNil)
+	c.Assert(notification.Subject, check.Equals, "")
+	c.Assert(notification.SubscribeURL, check.NotNil)
+	c.Assert(notification.UnsubscribeURL, check.Equals, "")
+	c.Assert(notification.Type, check.Equals, sns.MESSAGE_TYPE_UNSUBSCRIBE_CONFIRMATION)
+}

--- a/sns/sns_test.go
+++ b/sns/sns_test.go
@@ -1,7 +1,6 @@
 package sns_test
 
 import (
-	"encoding/json"
 	"github.com/crowdmob/goamz/aws"
 	"github.com/crowdmob/goamz/sns"
 	"github.com/crowdmob/goamz/testutil"
@@ -471,37 +470,4 @@ func (s *S) TestSetPlatformApplicationAttributes(c *check.C) {
 	c.Assert(resp.ResponseMetadata.RequestId, check.Equals, "cf577bcc-b3dc-5463-88f1-3180b9412395")
 
 	c.Assert(err, check.IsNil)
-}
-
-func (s *S) TestHttpSubscriptionConfirmationRequestUnmarshalling(c *check.C) {
-	notification := sns.HttpNotification{}
-	err := json.Unmarshal([]byte(HttpSubscriptionConfirmationRequest), &notification)
-	c.Assert(err, check.IsNil)
-	c.Assert(notification.Token, check.NotNil)
-	c.Assert(notification.Subject, check.Equals, "")
-	c.Assert(notification.SubscribeURL, check.NotNil)
-	c.Assert(notification.UnsubscribeURL, check.Equals, "")
-	c.Assert(notification.Type, check.Equals, sns.MESSAGE_TYPE_SUBSCRIPTION_CONFIRMATION)
-}
-
-func (s *S) TestHttpNotificationRequestUnmarshalling(c *check.C) {
-	notification := sns.HttpNotification{}
-	err := json.Unmarshal([]byte(HttpNotificationRequest), &notification)
-	c.Assert(err, check.IsNil)
-	c.Assert(notification.Token, check.Equals, "")
-	c.Assert(notification.Subject, check.NotNil)
-	c.Assert(notification.SubscribeURL, check.Equals, "")
-	c.Assert(notification.UnsubscribeURL, check.NotNil)
-	c.Assert(notification.Type, check.Equals, sns.MESSAGE_TYPE_NOTIFICATION)
-}
-
-func (s *S) TestHttpUnsubscribeConfirmationRequestUnmarshalling(c *check.C) {
-	notification := sns.HttpNotification{}
-	err := json.Unmarshal([]byte(HttpUnsubscribeConfirmationRequest), &notification)
-	c.Assert(err, check.IsNil)
-	c.Assert(notification.Token, check.NotNil)
-	c.Assert(notification.Subject, check.Equals, "")
-	c.Assert(notification.SubscribeURL, check.NotNil)
-	c.Assert(notification.UnsubscribeURL, check.Equals, "")
-	c.Assert(notification.Type, check.Equals, sns.MESSAGE_TYPE_UNSUBSCRIBE_CONFIRMATION)
 }

--- a/sns/structs.go
+++ b/sns/structs.go
@@ -2,7 +2,6 @@ package sns
 
 import (
 	"github.com/crowdmob/goamz/aws"
-	"time"
 )
 
 type Topic struct {
@@ -175,31 +174,4 @@ type SetEndpointAttributesResponse struct {
 
 type SetPlatformApplicationAttributesResponse struct {
 	ResponseMetadata aws.ResponseMetadata
-}
-
-//===== Http Json messages ======
-
-const (
-	MESSAGE_TYPE_SUBSCRIPTION_CONFIRMATION = "SubscriptionConfirmation"
-	MESSAGE_TYPE_UNSUBSCRIBE_CONFIRMATION  = "UnsubscribeConfirmation"
-	MESSAGE_TYPE_NOTIFICATION              = "Notification"
-)
-
-// Json http notifications
-// http://docs.aws.amazon.com/sns/latest/dg/json-formats.html#http-subscription-confirmation-json
-// http://docs.aws.amazon.com/sns/latest/dg/json-formats.html#http-notification-json
-// http://docs.aws.amazon.com/sns/latest/dg/json-formats.html#http-unsubscribe-confirmation-json
-type HttpNotification struct {
-	Type             string    `json:"Type"`
-	MessageId        string    `json:"MessageId"`
-	Token            string    `json:"Token" optional` // Only for subscribe and unsubscribe
-	TopicArn         string    `json:"TopicArn"`
-	Subject          string    `json:"Subject" optional` // Only for Notification
-	Message          string    `json:"Message"`
-	SubscribeURL     string    `json:"SubscribeURL" optional` // Only for subscribe and unsubscribe
-	Timestamp        time.Time `json:"Timestamp"`
-	SignatureVersion string    `json:"SignatureVersion"`
-	Signature        string    `json:"Signature"`
-	SigningCertURL   string    `json:"SigningCertURL"`
-	UnsubscribeURL   string    `json:"UnsubscribeURL" optional` // Only for notifications
 }


### PR DESCRIPTION
@alimoeeny based on our previous chat I rearranged the SNS code related to http endpoints into separated files. I also added a couple of convenience method to subscribe/unsubscribe following the json message.  
