### PR TITLE
Allowing a Description to be used for PutMetricAlarm method

### DIFF
--- a/cloudwatch/cloudwatch.go
+++ b/cloudwatch/cloudwatch.go
@@ -109,18 +109,19 @@ type AlarmAction struct {
 }
 
 type MetricAlarm struct {
-	AlarmActions       []AlarmAction
-	AlarmDescription   string
-	AlarmName          string
-	ComparisonOperator string
-	Dimensions         []Dimension
-	EvaluationPeriods  int
-	MetricName         string
-	Namespace          string
-	Period             int
-	Statistic          string
-	Threshold          float64
-	Unit               string
+	AlarmActions            []AlarmAction
+	AlarmDescription        string
+	AlarmName               string
+	ComparisonOperator      string
+	Dimensions              []Dimension
+	EvaluationPeriods       int
+	InsufficientDataActions []AlarmAction
+	MetricName              string
+	Namespace               string
+	Period                  int
+	Statistic               string
+	Threshold               float64
+	Unit                    string
 }
 
 var attempts = aws.AttemptStrategy{
@@ -426,6 +427,9 @@ func (c *CloudWatch) PutMetricAlarm(alarm *MetricAlarm) (result *aws.BaseRespons
 
 	for i, action := range alarm.AlarmActions {
 		params["AlarmActions.member."+strconv.Itoa(i+1)] = action.ARN
+	}
+	for i, action := range alarm.InsufficientDataActions {
+		params["InsufficientDataActions.member."+strconv.Itoa(i+1)] = action.ARN
 	}
 	if alarm.AlarmDescription != "" {
 		params["AlarmDescription"] = alarm.AlarmDescription

--- a/cloudwatch/cloudwatch.go
+++ b/cloudwatch/cloudwatch.go
@@ -429,9 +429,7 @@ func (c *CloudWatch) PutMetricAlarm(alarm *MetricAlarm) (result *aws.BaseRespons
 	}
 	if alarm.AlarmDescription != "" {
 		params["AlarmDescription"] = alarm.AlarmDescription
-		return
 	}
-	params["AlarmDescription"] = alarm.AlarmDescription
 	params["AlarmName"] = alarm.AlarmName
 	params["ComparisonOperator"] = alarm.ComparisonOperator
 	for i, dim := range alarm.Dimensions {

--- a/cloudwatch/cloudwatch_test.go
+++ b/cloudwatch/cloudwatch_test.go
@@ -33,6 +33,7 @@ func (s *S) TearDownTest(c *check.C) {
 func getTestAlarm() *cloudwatch.MetricAlarm {
 	alarm := new(cloudwatch.MetricAlarm)
 
+	alarm.AlarmDescription = "Test Description"
 	alarm.AlarmName = "TestAlarm"
 	alarm.MetricName = "TestMetric"
 	alarm.Namespace = "TestNamespace"


### PR DESCRIPTION
Adding description to test alarm and changing PutMetricAlarm to not exit if description is provided.